### PR TITLE
Upgrade social core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "social-auth-core==4.2.0",
+  "social-auth-core>=4.2.0",
   "social-auth-app-django==5.0.0"
 ]
 keywords = ["Open edX", "oauth", "Wordpress"]

--- a/requirements/stable-psa.txt
+++ b/requirements/stable-psa.txt
@@ -1,3 +1,3 @@
-# Stable Python Social Auth, found in Open edX Nutmeg
+# Stable Python Social Auth, found in Open edX Olive
 social-auth-app-django==5.0.0
-social-auth-core==4.2.0
+social-auth-core==4.3.0


### PR DESCRIPTION
Open edX Olive uses social-auth-core v4.3.0